### PR TITLE
Ensure courts list loads directly from JSP

### DIFF
--- a/Project_SWP/web/court_manager.jsp
+++ b/Project_SWP/web/court_manager.jsp
@@ -1,5 +1,13 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="DAO.CourtDAO,java.util.List,Model.Courts" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%
+    if (request.getAttribute("courts") == null) {
+        CourtDAO dao = new CourtDAO();
+        List<Courts> courts = dao.getAllCourts();
+        request.setAttribute("courts", courts);
+    }
+%>
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- fetch courts list on court_manager.jsp if it hasn't been provided

## Testing
- `ant -f build.xml -q dist` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e1d8771ec8327bb635eb0d8d91304