### PR TITLE
Update schedule page to use area hours

### DIFF
--- a/Project_SWP/src/java/controller/manager/ManagerBookingScheduleServlet.java
+++ b/Project_SWP/src/java/controller/manager/ManagerBookingScheduleServlet.java
@@ -96,12 +96,33 @@ public class ManagerBookingScheduleServlet extends HttpServlet {
         AreaDAO areaDAO = new AreaDAO();
         List<Branch> areas = areaDAO.getAreasByManager(managerId);
 
+        int openHour = 6;
+        int closeHour = 22;
+        if (areaId != null) {
+            Branch a = areaDAO.getAreaByIdWithManager(areaId);
+            if (a != null) {
+                openHour = a.getOpenTime().toLocalTime().getHour();
+                closeHour = a.getCloseTime().toLocalTime().getHour();
+            }
+        } else if (!areas.isEmpty()) {
+            openHour = 24;
+            closeHour = 0;
+            for (Branch a : areas) {
+                int oh = a.getOpenTime().toLocalTime().getHour();
+                int ch = a.getCloseTime().toLocalTime().getHour();
+                if (oh < openHour) openHour = oh;
+                if (ch > closeHour) closeHour = ch;
+            }
+        }
+
         request.setAttribute("areas", areas);
         request.setAttribute("bookings", bookings);
         request.setAttribute("schedule", schedule);
         request.setAttribute("weekDays", days);
         request.setAttribute("start", startDate);
         request.setAttribute("end", endDate);
+        request.setAttribute("openHour", openHour);
+        request.setAttribute("closeHour", closeHour);
         request.getRequestDispatcher("manager_booking_schedule.jsp").forward(request, response);
     }
 }

--- a/Project_SWP/web/manager_booking_schedule.jsp
+++ b/Project_SWP/web/manager_booking_schedule.jsp
@@ -56,7 +56,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                <c:forEach begin="6" end="15" var="h">
+                <c:forEach begin="${openHour}" end="${closeHour - 1}" var="h">
                     <tr>
                         <th>${h}:00</th>
                         <c:forEach var="d" items="${weekDays}">


### PR DESCRIPTION
## Summary
- fetch open and close times for the selected area in `ManagerBookingScheduleServlet`
- compute earliest open and latest close hours if no area is selected
- pass hours to the JSP and loop using these values

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e47453ec4832794af5dd0caad25b1