### PR TITLE
Add rating modal with comment support

### DIFF
--- a/Project_SWP/src/java/DAO/ReviewDAO.java
+++ b/Project_SWP/src/java/DAO/ReviewDAO.java
@@ -38,7 +38,21 @@ public int countReviewsByManager(int managerId) {
         System.out.println(e.getMessage());
     }
     return 0;
-}
+    }
+
+    public boolean addReview(int userId, int areaId, int rating, String comment) {
+        String sql = "INSERT INTO Reviews (user_id, area_id, rating, comment) VALUES (?, ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            ps.setInt(2, areaId);
+            ps.setInt(3, rating);
+            ps.setString(4, comment);
+            return ps.executeUpdate() > 0;
+        } catch (SQLException e) {
+            System.out.println(e.getMessage());
+        }
+        return false;
+    }
 BookingDAO dao = new BookingDAO();
 public int countByArea(int areaId) {
     return dao.countBookingsByArea(areaId);

--- a/Project_SWP/src/java/controller/user/SubmitRatingServlet.java
+++ b/Project_SWP/src/java/controller/user/SubmitRatingServlet.java
@@ -1,6 +1,8 @@
 package controller.user;
 
 import DAO.BookingDAO;
+import DAO.CourtDAO;
+import DAO.ReviewDAO;
 import Model.Bookings;
 import Model.User;
 import java.io.IOException;
@@ -40,7 +42,13 @@ public class SubmitRatingServlet extends HttpServlet {
                 response.sendRedirect("booking-list?error=invalid-status");
                 return;
             }
+            String comment = request.getParameter("comment");
             dao.updateRating(bookingId, rating);
+
+            CourtDAO cDao = new CourtDAO();
+            ReviewDAO rDao = new ReviewDAO();
+            int areaId = cDao.getCourtById(booking.getCourt_id()).getArea_id();
+            rDao.addReview(user.getUser_Id(), areaId, rating, comment);
         } catch (NumberFormatException e) {
             // ignore invalid number
         }

--- a/Project_SWP/web/booking_list.jsp
+++ b/Project_SWP/web/booking_list.jsp
@@ -73,6 +73,27 @@
                 text-decoration: none;
             }
 
+            .star-rating {
+                direction: rtl;
+                display: inline-flex;
+                font-size: 1.5rem;
+            }
+
+            .star-rating input[type="radio"] {
+                display: none;
+            }
+
+            .star-rating label {
+                color: #ccc;
+                cursor: pointer;
+            }
+
+            .star-rating input[type="radio"]:checked ~ label,
+            .star-rating label:hover,
+            .star-rating label:hover ~ label {
+                color: #ffca08;
+            }
+
         </style>
     </head>
     <body>
@@ -108,11 +129,14 @@
                                         <c:when test="${booking.status eq 'confirmed'}">
                                             <c:choose>
                                                 <c:when test="${booking.rating == 0}">
-                                                    <form action="submit-rating" method="post" class="d-flex">
-                                                        <input type="hidden" name="bookingId" value="${booking.booking_id}"/>
-                                                        <input type="number" name="rating" min="1" max="5" class="form-control form-control-sm me-2" required/>
-                                                        <button type="submit" class="btn btn-primary btn-sm">Đánh giá</button>
-                                                    </form>
+                                                    <button type="button" class="btn btn-primary btn-sm open-rating-modal"
+                                                            data-bs-toggle="modal" data-bs-target="#ratingModal"
+                                                            data-booking="${booking.booking_id}"
+                                                            data-court="${booking.court_id}"
+                                                            data-date="${booking.date}"
+                                                            data-time="${booking.start_time} - ${booking.end_time}">
+                                                        Đánh giá
+                                                    </button>
                                                 </c:when>
                                                 <c:otherwise>
                                                     ${booking.rating}
@@ -137,6 +161,44 @@
                     </tbody>
                 </table>
             </div>
+            <!-- Rating Modal -->
+            <div class="modal fade" id="ratingModal" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog">
+                    <form class="modal-content" action="submit-rating" method="post">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Đánh giá sân</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <p id="courtInfo" class="fw-bold mb-1"></p>
+                            <p id="dateInfo" class="mb-3"></p>
+                            <input type="hidden" name="bookingId" id="bookingIdInput" />
+                            <div class="star-rating mb-3">
+                                <input type="radio" id="star5" name="rating" value="5"/><label for="star5">★</label>
+                                <input type="radio" id="star4" name="rating" value="4"/><label for="star4">★</label>
+                                <input type="radio" id="star3" name="rating" value="3"/><label for="star3">★</label>
+                                <input type="radio" id="star2" name="rating" value="2"/><label for="star2">★</label>
+                                <input type="radio" id="star1" name="rating" value="1"/><label for="star1">★</label>
+                            </div>
+                            <textarea name="comment" class="form-control" placeholder="Nhận xét của bạn"></textarea>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
+                            <button type="submit" class="btn btn-primary">Gửi đánh giá</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+            <script>
+                var ratingModal = document.getElementById('ratingModal');
+                ratingModal.addEventListener('show.bs.modal', function (event) {
+                    var button = event.relatedTarget;
+                    document.getElementById('courtInfo').textContent = 'Sân: ' + button.getAttribute('data-court');
+                    document.getElementById('dateInfo').textContent = 'Ngày: ' + button.getAttribute('data-date') + ' (' + button.getAttribute('data-time') + ')';
+                    document.getElementById('bookingIdInput').value = button.getAttribute('data-booking');
+                });
+            </script>
         </main>
 
         <jsp:include page="homefooter.jsp" />


### PR DESCRIPTION
## Summary
- enhance rating form with modal and star rating
- allow users to add comments when rating
- store comment in Reviews table via new DAO method

## Testing
- `ant -q jar` *(fails: ant not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684fdb67419883279b284e015ba569c3