### PR TITLE
Enable court image uploads

### DIFF
--- a/Project_SWP/src/java/controller/manager/CourtServlet.java
+++ b/Project_SWP/src/java/controller/manager/CourtServlet.java
@@ -4,15 +4,21 @@ import DAO.AreaDAO;
 import DAO.CourtDAO;
 import Model.Courts;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.Part;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
 @WebServlet("/courts")
+@MultipartConfig(fileSizeThreshold = 1024 * 1024,
+        maxFileSize = 1024 * 1024 * 10,
+        maxRequestSize = 1024 * 1024 * 20)
 public class CourtServlet extends HttpServlet {
 
     private CourtDAO courtDAO;
@@ -49,7 +55,18 @@ public class CourtServlet extends HttpServlet {
             court.setFloor_material(request.getParameter("floorMaterial"));
             court.setLighting(request.getParameter("lighting"));
             court.setDescription(request.getParameter("description"));
-            court.setImage_url(request.getParameter("imageUrl"));
+
+            Part filePart = request.getPart("image");
+            String imagePath = null;
+            if (filePart != null && filePart.getSize() > 0) {
+                String fileName = System.currentTimeMillis() + "_" + filePart.getSubmittedFileName();
+                String uploadDir = getServletContext().getRealPath("/uploads");
+                File dir = new File(uploadDir);
+                if (!dir.exists()) dir.mkdirs();
+                filePart.write(uploadDir + File.separator + fileName);
+                imagePath = "uploads/" + fileName;
+            }
+            court.setImage_url(imagePath);
             court.setStatus(request.getParameter("status"));
             court.setArea_id(Integer.parseInt(request.getParameter("areaId")));
             courtDAO.addCourt(court);
@@ -64,7 +81,18 @@ public class CourtServlet extends HttpServlet {
             court.setFloor_material(request.getParameter("floorMaterial"));
             court.setLighting(request.getParameter("lighting"));
             court.setDescription(request.getParameter("description"));
-            court.setImage_url(request.getParameter("imageUrl"));
+
+            Part filePart = request.getPart("image");
+            String imagePath = request.getParameter("currentImage");
+            if (filePart != null && filePart.getSize() > 0) {
+                String fileName = System.currentTimeMillis() + "_" + filePart.getSubmittedFileName();
+                String uploadDir = getServletContext().getRealPath("/uploads");
+                File dir = new File(uploadDir);
+                if (!dir.exists()) dir.mkdirs();
+                filePart.write(uploadDir + File.separator + fileName);
+                imagePath = "uploads/" + fileName;
+            }
+            court.setImage_url(imagePath);
             court.setStatus(request.getParameter("status"));
             int areaId = Integer.parseInt(request.getParameter("areaId"));
             court.setArea_id(areaId);

--- a/Project_SWP/web/CourtDetail.jsp
+++ b/Project_SWP/web/CourtDetail.jsp
@@ -34,7 +34,7 @@
         <c:forEach var="court" items="${courts}">
             <div class="col-md-4">
                 <div class="card h-100 shadow-sm border-0">
-                    <img src="${court.image_url}" class="card-img-top" style="height: 200px; object-fit: cover;" alt="Ảnh sân ${court.court_number}">
+                    <img src="${pageContext.request.contextPath}/${court.image_url}" class="card-img-top" style="height: 200px; object-fit: cover;" alt="Ảnh sân ${court.court_number}">
                     <div class="card-body d-flex flex-column justify-content-between">
                         <div>
                             <h5 class="card-title fw-bold">Sân ${court.court_number}</h5>

--- a/Project_SWP/web/court_manager.jsp
+++ b/Project_SWP/web/court_manager.jsp
@@ -184,7 +184,7 @@
                     <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
                 </div>
                 <div class="modal-body">
-                    <form action="courts" method="post">
+                    <form action="courts" method="post" enctype="multipart/form-data">
                         <input type="hidden" name="action" value="add">
                         <div class="form-group">
                             <label>Tên Sân</label>
@@ -207,8 +207,8 @@
                             <input type="text" class="form-control" name="description">
                         </div>
                         <div class="form-group">
-                            <label>Ảnh URL</label>
-                            <input type="text" class="form-control" name="imageUrl">
+                            <label>Ảnh</label>
+                            <input type="file" class="form-control" name="image" accept="image/*">
                         </div>
                         <div class="form-group">
                             <label>Trạng Thái</label>
@@ -242,7 +242,7 @@
                     <button type="button" class="close" data-dismiss="modal"><span>&times;</span></button>
                 </div>
                 <div class="modal-body">
-                    <form action="courts" method="post">
+                    <form action="courts" method="post" enctype="multipart/form-data">
                         <input type="hidden" name="action" value="update">
                         <input type="hidden" name="courtId" id="updateCourtId">
                         <div class="form-group">
@@ -265,9 +265,10 @@
                             <label>Mô Tả</label>
                             <input type="text" class="form-control" id="updateDescription" name="description">
                         </div>
+                        <input type="hidden" name="currentImage" id="currentImage">
                         <div class="form-group">
-                            <label>Ảnh URL</label>
-                            <input type="text" class="form-control" id="updateImageUrl" name="imageUrl">
+                            <label>Ảnh</label>
+                            <input type="file" class="form-control" id="updateImage" name="image" accept="image/*">
                         </div>
                         <div class="form-group">
                             <label>Trạng Thái</label>
@@ -307,7 +308,6 @@
                         <th>Chất Liệu</th>
                         <th>Chiếu Sáng</th>
                         <th>Mô Tả</th>
-                        <th>Ảnh</th>
                         <th>Trạng Thái</th>
                         <th>Khu Vực ID</th>
                         <th>Hành Động</th>
@@ -322,7 +322,6 @@
                             <td>${court.floor_material}</td>
                             <td>${court.lighting}</td>
                             <td>${court.description}</td>
-                            <td>${court.image_url}</td>
                             <td>${court.status}</td>
                             <td>${court.area_id}</td>
                             <td>
@@ -333,7 +332,6 @@
                                         data-floor="${court.floor_material}"
                                         data-lighting="${court.lighting}"
                                         data-description="${court.description}"
-                                        data-image="${court.image_url}"
                                         data-status="${court.status}"
                                         data-area="${court.area_id}"
                                         ><i class="fas fa-edit"></i> Sửa</button>
@@ -403,7 +401,7 @@
             document.getElementById('updateFloorMaterial').value = this.dataset.floor || '';
             document.getElementById('updateLighting').value = this.dataset.lighting || '';
             document.getElementById('updateDescription').value = this.dataset.description || '';
-            document.getElementById('updateImageUrl').value = this.dataset.image || '';
+            document.getElementById('currentImage').value = this.dataset.image || '';
             document.getElementById('updateStatus').value = this.dataset.status;
             document.getElementById('updateAreaId').value = this.dataset.area;
             $('#updateCourtModal').modal('show');

--- a/Project_SWP/web/staff_court_detail.jsp
+++ b/Project_SWP/web/staff_court_detail.jsp
@@ -23,7 +23,7 @@
             <tr><th>Chiếu sáng</th><td>${court.lighting}</td></tr>
             <tr><th>Mô tả</th><td>${court.description}</td></tr>
             <tr><th>Ảnh</th>
-                <td><c:if test='${not empty court.image_url}'><img src='${court.image_url}' width='300'/></c:if></td></tr>
+                <td><c:if test='${not empty court.image_url}'><img src='${pageContext.request.contextPath}/${court.image_url}' width='300'/></c:if></td></tr>
             <tr><th>Trạng thái</th><td>${court.status}</td></tr>
             <tr><th>Area ID</th><td>${court.area_id}</td></tr>
         </table>


### PR DESCRIPTION
## Summary
- allow uploading images when adding or updating courts
- drop image column from the court manager list
- display uploaded images in court detail views

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685058c43f8883278a63446659e14b98