### PR TITLE
Integrate court manager with region view

### DIFF
--- a/Project_SWP/src/java/controller/manager/CourtServlet.java
+++ b/Project_SWP/src/java/controller/manager/CourtServlet.java
@@ -31,8 +31,16 @@ public class CourtServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String action = request.getParameter("action");
+        String areaParam = request.getParameter("area_id");
         if (action == null) {
-            List<Courts> courts = courtDAO.getAllCourts();
+            List<Courts> courts;
+            if (areaParam != null && !areaParam.isEmpty()) {
+                int areaId = Integer.parseInt(areaParam);
+                courts = courtDAO.getCourtsByAreaId(areaId);
+                request.setAttribute("areaId", areaId);
+            } else {
+                courts = courtDAO.getAllCourts();
+            }
             request.setAttribute("courts", courts);
             request.getRequestDispatcher("/court_manager.jsp").forward(request, response);
         } else if (action.equals("edit")) {
@@ -107,6 +115,11 @@ public class CourtServlet extends HttpServlet {
             session.setAttribute("successMessage", "Xóa sân thành công!");
             session.setAttribute("messageType", "success");
         }
-        response.sendRedirect("courts");
+        String redirectArea = request.getParameter("redirectAreaId");
+        String redirectUrl = "courts";
+        if (redirectArea != null && !redirectArea.isEmpty()) {
+            redirectUrl += "?area_id=" + redirectArea;
+        }
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/Project_SWP/web/Sidebar.jsp
+++ b/Project_SWP/web/Sidebar.jsp
@@ -79,9 +79,6 @@
                     <a class="nav-link " href="view-region">REGION MANAGEMENT</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="courts">COURT MANAGEMENT</a>
-                </li>
-                <li class="nav-item">
                     <a class="nav-link" href="ViewService">SERVICE MANAGEMENT</a>
                 </li>
                 <li class="nav-item">

--- a/Project_SWP/web/court_manager.jsp
+++ b/Project_SWP/web/court_manager.jsp
@@ -186,6 +186,9 @@
                 <div class="modal-body">
                     <form action="courts" method="post" enctype="multipart/form-data">
                         <input type="hidden" name="action" value="add">
+                        <c:if test="${not empty areaId}">
+                            <input type="hidden" name="redirectAreaId" value="${areaId}">
+                        </c:if>
                         <div class="form-group">
                             <label>Tên Sân</label>
                             <input type="text" class="form-control" name="courtNumber" required>
@@ -220,7 +223,7 @@
                         </div>
                         <div class="form-group">
                             <label>Khu Vực ID</label>
-                            <input type="number" class="form-control" id="addAreaId" name="areaId" required min="1">
+                            <input type="number" class="form-control" id="addAreaId" name="areaId" required min="1" value="${areaId}">
                             <small class="form-text text-muted">Nhập ID khu vực hợp lệ</small>
                         </div>
                         <div class="modal-footer">
@@ -244,6 +247,9 @@
                 <div class="modal-body">
                     <form action="courts" method="post" enctype="multipart/form-data">
                         <input type="hidden" name="action" value="update">
+                        <c:if test="${not empty areaId}">
+                            <input type="hidden" name="redirectAreaId" value="${areaId}">
+                        </c:if>
                         <input type="hidden" name="courtId" id="updateCourtId">
                         <div class="form-group">
                             <label>Tên Sân</label>
@@ -337,6 +343,9 @@
                                         ><i class="fas fa-edit"></i> Sửa</button>
                                 <form action="courts" method="post" style="display: inline;">
                                     <input type="hidden" name="action" value="delete">
+                                    <c:if test="${not empty areaId}">
+                                        <input type="hidden" name="redirectAreaId" value="${areaId}">
+                                    </c:if>
                                     <input type="hidden" name="courtId" value="${court.court_id}">
                                     <button type="submit" class="btn btn-sm btn-danger"
                                             onclick="return confirm('Bạn có chắc muốn xóa sân này?')">

--- a/Project_SWP/web/manager-region.jsp
+++ b/Project_SWP/web/manager-region.jsp
@@ -103,7 +103,9 @@
                                         <tr>
                                             <td>${a.name}</td>
                                             <td>${a.location}</td>
-                                            <td>${a.emptyCourt}</td>
+                                            <td>
+                                                <a href="courts?area_id=${a.area_id}">${a.emptyCourt}</a>
+                                            </td>
                                             <td>${a.openTime}</td>
                                             <td>${a.closeTime}</td>
                                             <td>${a.description}</td>


### PR DESCRIPTION
## Summary
- remove the dedicated **Court Management** entry from the sidebar
- link each region's court count to the court manager page
- filter courts by area in `CourtServlet` and preserve the current region when performing actions
- keep the selected region when adding, editing or deleting courts

## Testing
- `ant -noinput test` *(fails: `ant: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68506bb3b0d88327a30afb7e1b9233a9