### PR TITLE
Fix court pricing decimal handling

### DIFF
--- a/Project_SWP/src/java/DAO/CourtPricingDAO.java
+++ b/Project_SWP/src/java/DAO/CourtPricingDAO.java
@@ -24,8 +24,8 @@ public class CourtPricingDAO extends DBContext{
             System.out.println("Connect failed");
         }
     }
-    public int calculatePrice(int areaId, Time start, Time end) {
-    int total = 0;
+    public double calculatePrice(int areaId, Time start, Time end) {
+    double total = 0;
     try {
         String sql = "SELECT * FROM Court_Pricing WHERE area_id = ?";
         PreparedStatement ps = conn.prepareStatement(sql);
@@ -34,7 +34,7 @@ public class CourtPricingDAO extends DBContext{
         while (rs.next()) {
             Time pricingStart = rs.getTime("start_time");
             Time pricingEnd = rs.getTime("end_time");
-            int price = rs.getInt("price");
+            double price = rs.getDouble("price");
 
             // Nếu khoảng thời gian nằm trong khung giá
             if (!(end.before(pricingStart) || start.after(pricingEnd))) {

--- a/Project_SWP/src/java/controller/user/BookFieldServlet.java
+++ b/Project_SWP/src/java/controller/user/BookFieldServlet.java
@@ -138,7 +138,7 @@ try {
         }
 
         CourtPricingDAO pricingDAO = new CourtPricingDAO();
-        int totalPrice = pricingDAO.calculatePrice(court.getArea_id(), startTime, endTime);
+        double totalPrice = pricingDAO.calculatePrice(court.getArea_id(), startTime, endTime);
 
         request.setAttribute("court", court);
         request.setAttribute("date", date);


### PR DESCRIPTION
## Summary
- use `double` for computed court pricing values
- adjust `BookFieldServlet` to handle `double` pricing

## Testing
- `ant -q -Dnb.internal.action.name=build` *(fails: `ant` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851daf5707c83279414dc6959301119