### PR TITLE
Fix status validation for ratings

### DIFF
--- a/Project_SWP/src/java/controller/user/SubmitRatingServlet.java
+++ b/Project_SWP/src/java/controller/user/SubmitRatingServlet.java
@@ -38,7 +38,7 @@ public class SubmitRatingServlet extends HttpServlet {
                 response.sendRedirect("booking-list?error=unauthorized");
                 return;
             }
-            if (!"confirmed".equals(booking.getStatus())) {
+            if (!"completed".equals(booking.getStatus())) {
                 response.sendRedirect("booking-list?error=invalid-status");
                 return;
             }


### PR DESCRIPTION
## Summary
- swap booking status check from `confirmed` to `completed`

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c6ef9fc083279ce7ea3f2682c0c4