### PR TITLE
Add completed status option

### DIFF
--- a/Project_SWP/web/update_booking.jsp
+++ b/Project_SWP/web/update_booking.jsp
@@ -58,6 +58,7 @@
                 <option value="pending" <c:if test="${booking.status eq 'pending'}">selected</c:if>>Pending</option>
                 <option value="confirmed" <c:if test="${booking.status eq 'confirmed'}">selected</c:if>>Confirmed</option>
                 <option value="cancelled" <c:if test="${booking.status eq 'cancelled'}">selected</c:if>>Cancelled</option>
+                <option value="completed" <c:if test="${booking.status eq 'completed'}">selected</c:if>>Completed</option>
             </select>
         </div>
                         <div class="col-12">


### PR DESCRIPTION
## Summary
- add a Completed status option to the update booking page

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852c8bbe04083279832f13bc6f58467