### PR TITLE
Restrict rating to completed bookings

### DIFF
--- a/Project_SWP/web/booking_list.jsp
+++ b/Project_SWP/web/booking_list.jsp
@@ -141,7 +141,7 @@
                         </td>
                                 <td>
                                     <c:choose>
-                                        <c:when test="${booking.status eq 'confirmed'}">
+                                        <c:when test="${booking.status eq 'completed'}">
                                             <c:choose>
                                                 <c:when test="${booking.rating == 0}">
                                                     <button type="button" class="btn btn-primary btn-sm open-rating-modal"


### PR DESCRIPTION
## Summary
- only display rating button on booking list when status is `completed`

## Testing
- `ant -p` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852d1f779548327a95d48c14e6b3fb2