### PR TITLE
Allow manual entry of booking customer name

### DIFF
--- a/Project_SWP/src/java/DAO/BookingDAO.java
+++ b/Project_SWP/src/java/DAO/BookingDAO.java
@@ -237,8 +237,9 @@ public List<Slot> getAvailableSlots(int courtId, LocalDate date) {
 
             ps.setInt(1, courtId);
             ps.setDate(2, java.sql.Date.valueOf(date));
-            ps.setObject(3, endTime, java.sql.Types.TIME);
-            ps.setObject(4, startTime, java.sql.Types.TIME);
+            // Check overlap using new booking's startTime and endTime
+            ps.setObject(3, startTime, java.sql.Types.TIME);
+            ps.setObject(4, endTime, java.sql.Types.TIME);
 
             ResultSet rs = ps.executeQuery();
             boolean hasConflict = rs.next();

--- a/Project_SWP/web/add_booking.jsp
+++ b/Project_SWP/web/add_booking.jsp
@@ -32,12 +32,8 @@
                     </c:if>
                     <form action="add-booking" method="post" class="row g-3">
         <div class="col-md-6">
-            <label class="form-label">Khách Hàng</label>
-            <select name="userId" class="form-select" required>
-                <c:forEach var="c" items="${customers}">
-                    <option value="${c.user_Id}">${c.username}</option>
-                </c:forEach>
-            </select>
+            <label class="form-label">Tên khách hàng</label>
+            <input type="text" name="username" class="form-control" required/>
         </div>
         <div class="col-md-6">
             <label class="form-label">Sân</label>


### PR DESCRIPTION
## Summary
- support entering a customer name directly when creating a booking
- create new user record automatically if the name does not exist
- fix slot availability check

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f9495a86c832eaa437ba92929947b