### PR TITLE
Simplify staff sidebar and redirect to dashboard

### DIFF
--- a/Project_SWP/build/web/Sidebar_Staff.jsp
+++ b/Project_SWP/build/web/Sidebar_Staff.jsp
@@ -246,18 +246,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="notification_list">QUẢN LÝ THÔNG BÁO</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="promotion-admin">QUẢN LÝ KHUYẾN MÃI</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="faq-list">QUẢN LÝ CÂU HỎI THƯỜNG GẶP</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="revenue-report">BÁO CÁO</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="banner-list">BANNER</a>
-                    </li>
                 </ul>
             </div>
         </div>

--- a/Project_SWP/src/java/controller/user/LoginController.java
+++ b/Project_SWP/src/java/controller/user/LoginController.java
@@ -113,7 +113,7 @@ public class LoginController extends HttpServlet {
             }
 
             if ("staff".equalsIgnoreCase(user.getRole())) {
-                response.sendRedirect("view-region");
+                response.sendRedirect("staff-dashboard");
             } else if ("admin".equalsIgnoreCase(user.getRole())) {
                 response.sendRedirect("Admin_DashBoard.jsp");
             } else {

--- a/Project_SWP/web/Sidebar_Staff.jsp
+++ b/Project_SWP/web/Sidebar_Staff.jsp
@@ -246,18 +246,6 @@
                     <li class="nav-item">
                         <a class="nav-link" href="notification_list">QUẢN LÝ THÔNG BÁO</a>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="promotion-admin">QUẢN LÝ KHUYẾN MÃI</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="faq-list">QUẢN LÝ CÂU HỎI THƯỜNG GẶP</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="revenue-report">BÁO CÁO</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="banner-list">BANNER</a>
-                    </li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- simplify staff sidebar to only show relevant actions
- redirect staff users to the staff dashboard after login

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686fee66dbd0832e8b31ad86112382d0