### PR TITLE
Add role-aware sidebar selection

### DIFF
--- a/Project_SWP/web/ManagerPost.jsp
+++ b/Project_SWP/web/ManagerPost.jsp
@@ -55,7 +55,14 @@
         </div>
 
         <div class="row g-0">
-            <jsp:include page="Sidebar.jsp"/>
+            <c:choose>
+                <c:when test="${sessionScope.user.role eq 'staff'}">
+                    <jsp:include page="Sidebar_Staff.jsp" />
+                </c:when>
+                <c:otherwise>
+                    <jsp:include page="Sidebar.jsp" />
+                </c:otherwise>
+            </c:choose>
             <div class="col-10 pt-5 px-4">
                 <div class="card card-main px-4 py-3 " style="width:100%; max-width:1200px; margin-left: 270px;">
                     <div class="d-flex align-items-center mb-3">

--- a/Project_SWP/web/ServiceView.jsp
+++ b/Project_SWP/web/ServiceView.jsp
@@ -198,7 +198,14 @@
         </style>
     </head>
     <body>
-        <jsp:include page="Sidebar.jsp" />
+        <c:choose>
+            <c:when test="${sessionScope.user.role eq 'staff'}">
+                <jsp:include page="Sidebar_Staff.jsp" />
+            </c:when>
+            <c:otherwise>
+                <jsp:include page="Sidebar.jsp" />
+            </c:otherwise>
+        </c:choose>
         <%
             List<Service> service = (List<Service>) request.getAttribute("service");
             if (service == null) service = java.util.Collections.emptyList();

--- a/Project_SWP/web/court_manager.jsp
+++ b/Project_SWP/web/court_manager.jsp
@@ -703,7 +703,14 @@
 <div class="container-fluid">
     <div class="row mt-4">
         <div class="col-md-2 mb-4">
-            <jsp:include page="Sidebar.jsp" />
+            <c:choose>
+                <c:when test="${sessionScope.user.role eq 'staff'}">
+                    <jsp:include page="Sidebar_Staff.jsp" />
+                </c:when>
+                <c:otherwise>
+                    <jsp:include page="Sidebar.jsp" />
+                </c:otherwise>
+            </c:choose>
         </div>
         <div class="col-md-10">
             <!-- Thông báo -->

--- a/Project_SWP/web/manager_booking_schedule.jsp
+++ b/Project_SWP/web/manager_booking_schedule.jsp
@@ -404,7 +404,14 @@
     <div class="row g-0">
         <!-- Sidebar -->
         <div class="col-md-3 d-none d-md-block">
-            <jsp:include page="Sidebar.jsp"/>
+            <c:choose>
+                <c:when test="${sessionScope.user.role eq 'staff'}">
+                    <jsp:include page="Sidebar_Staff.jsp" />
+                </c:when>
+                <c:otherwise>
+                    <jsp:include page="Sidebar.jsp" />
+                </c:otherwise>
+            </c:choose>
         </div>
 
         <!-- Main Content -->


### PR DESCRIPTION
## Summary
- show `Sidebar_Staff.jsp` when the logged in user is staff
- fall back to the default sidebar for other roles

## Testing
- `ant test` *(fails: libs.CopyLibs.classpath property is not set up)*
- `ant compile` *(fails: libs.CopyLibs.classpath property is not set up)*

------
https://chatgpt.com/codex/tasks/task_b_68726a581c44832e9c20392d284809f6