### PR TITLE
Compute shift price with promotions

### DIFF
--- a/Project_SWP/src/java/controller/manager/AddBookingServlet.java
+++ b/Project_SWP/src/java/controller/manager/AddBookingServlet.java
@@ -7,11 +7,13 @@ import DAO.UserDAO;
 import DAO.AreaDAO;
 import DAO.ServiceDAO;
 import DAO.ShiftDAO;
+import DAO.PromotionDAO;
 import Model.Shift;
 import Model.Branch;
 import Model.Courts;
 import Model.Service;
 import Model.User;
+import Model.Promotion;
 import utils.PasswordUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -20,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -108,19 +111,9 @@ public class AddBookingServlet extends HttpServlet {
             BookingDAO bookingDAO = new BookingDAO();
             Branch branch = new AreaDAO().getAreaByIdWithManager(court.getArea_id());
 
-            // Calculate total price for this booking
-            double total = court.getPrice();
-            if (selectedServices != null) {
-                for (String id : selectedServices) {
-                    try {
-                        Service s = ServiceDAO.getServiceById(Integer.parseInt(id));
-                        if (s != null) {
-                            total += s.getPrice();
-                        }
-                    } catch (NumberFormatException ignored) {
-                    }
-                }
-            }
+            PromotionDAO proDao = new PromotionDAO();
+            Promotion promotion = proDao.getCurrentPromotionForArea(court.getArea_id(), date);
+            BigDecimal pricePerHour = courtDAO.getCourtPrice(courtId);
 
             java.util.List<String> conflicts = new java.util.ArrayList<>();
 
@@ -161,8 +154,21 @@ public class AddBookingServlet extends HttpServlet {
                     continue;
                 }
 
+                BigDecimal shiftTotal = bookingDAO.calculateSlotPriceWithPromotion(startTime, endTime, pricePerHour, promotion);
+                if (selectedServices != null) {
+                    for (String id : selectedServices) {
+                        try {
+                            Service s = ServiceDAO.getServiceById(Integer.parseInt(id));
+                            if (s != null) {
+                                shiftTotal = shiftTotal.add(BigDecimal.valueOf(s.getPrice()));
+                            }
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+                }
+
                 int bookingId = bookingDAO.insertBookingWithTotalPrice(userId, courtId, date,
-                        startTime, endTime, "pending", java.math.BigDecimal.valueOf(total));
+                        startTime, endTime, "pending", shiftTotal);
                 if (bookingId == -1) {
                     conflicts.add("Lỗi tạo booking " + sh.getShiftName());
                     continue;


### PR DESCRIPTION
## Summary
- update AddBookingServlet imports for promotion handling
- calculate total price per shift using `BookingDAO.calculateSlotPriceWithPromotion`
- add service fees to each shift total before persisting

## Testing
- `ant` *(fails: libs.CopyLibs.classpath property is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68741174db20832ebffb911462f36d0f