### PR TITLE
Enable modal-based booking in calendar

### DIFF
--- a/Project_SWP/src/java/controller/calendar/CalendarBookingServlet.java
+++ b/Project_SWP/src/java/controller/calendar/CalendarBookingServlet.java
@@ -1,0 +1,56 @@
+package controller.calendar;
+
+import DAO.BookingDAO;
+import Model.User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.sql.Time;
+import java.time.LocalDate;
+import java.util.Collections;
+
+@WebServlet("/calendar-booking")
+public class CalendarBookingServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+        User user = session != null ? (User) session.getAttribute("user") : null;
+        if (user == null) {
+            response.sendRedirect("login");
+            return;
+        }
+        request.setCharacterEncoding("UTF-8");
+        String bookingIdStr = request.getParameter("bookingId");
+        String courtIdStr = request.getParameter("courtId");
+        String dateStr = request.getParameter("date");
+        String startStr = request.getParameter("startTime");
+        String endStr = request.getParameter("endTime");
+        String status = request.getParameter("status");
+        int bookingId = -1;
+        try { bookingId = Integer.parseInt(bookingIdStr); } catch (Exception ignored) {}
+        int courtId = -1;
+        try { courtId = Integer.parseInt(courtIdStr); } catch (Exception ignored) {}
+        LocalDate date = null;
+        try { date = LocalDate.parse(dateStr); } catch (Exception ignored) {}
+        Time start = null;
+        Time end = null;
+        try { if (startStr != null) start = Time.valueOf(startStr); } catch (Exception ignored) {}
+        try { if (endStr != null) end = Time.valueOf(endStr); } catch (Exception ignored) {}
+        if (courtId == -1 || date == null || start == null || end == null || status == null || status.isEmpty()) {
+            response.sendRedirect("booking-calendar");
+            return;
+        }
+        BookingDAO dao = new BookingDAO();
+        if (bookingId > 0) {
+            dao.updateBooking(bookingId, date, start, end, status, Collections.emptyList());
+        } else {
+            dao.insertBooking(user.getUser_Id(), courtId, date, start, end, status);
+        }
+        response.sendRedirect("booking-calendar");
+    }
+}

--- a/Project_SWP/src/java/controller/user/UserBookingCalendar.java
+++ b/Project_SWP/src/java/controller/user/UserBookingCalendar.java
@@ -1,7 +1,9 @@
 package controller.user;
 
 import DAO.BookingDAO;
+import DAO.CourtDAO;
 import Model.Bookings;
+import Model.Courts;
 import Model.User;
 import com.google.gson.Gson;
 import jakarta.servlet.ServletException;
@@ -41,6 +43,8 @@ public class UserBookingCalendar extends HttpServlet {
 
         BookingDAO dao = new BookingDAO();
         List<Bookings> bookings = dao.getBookingsForUser(user.getUser_Id(), from, to, status);
+        CourtDAO courtDAO = new CourtDAO();
+        List<Courts> courts = courtDAO.getAllCourts();
 
         if ("json".equalsIgnoreCase(request.getParameter("format"))) {
             response.setContentType("application/json;charset=UTF-8");
@@ -52,6 +56,7 @@ public class UserBookingCalendar extends HttpServlet {
         }
 
         request.setAttribute("bookings", bookings);
+        request.setAttribute("courts", courts);
         request.setAttribute("fromDate", fromStr);
         request.setAttribute("toDate", toStr);
         request.setAttribute("status", status);

--- a/Project_SWP/web/booking_calendar.jsp
+++ b/Project_SWP/web/booking_calendar.jsp
@@ -9,6 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css' rel='stylesheet' />
     <script src='https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js'></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <style>
         #calendar {
             max-width: 900px;
@@ -44,20 +45,102 @@
         </div>
     </form>
     <div id='calendar'></div>
+
+    <!-- Booking Modal -->
+    <div class="modal fade" id="bookingModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <form id="bookingForm" action="calendar-booking" method="post">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Đặt sân</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <input type="hidden" name="bookingId" id="bookingId">
+                        <div class="mb-3">
+                            <label class="form-label">Ngày</label>
+                            <input type="date" class="form-control" name="date" id="bookingDate" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Bắt đầu</label>
+                            <input type="time" class="form-control" name="startTime" id="startTime" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Kết thúc</label>
+                            <input type="time" class="form-control" name="endTime" id="endTime" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Sân</label>
+                            <select class="form-select" name="courtId" id="courtId" required>
+                                <c:forEach var="c" items="${courts}">
+                                    <option value="${c.court_id}">Sân ${c.court_number}</option>
+                                </c:forEach>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Người đặt</label>
+                            <input type="text" class="form-control" name="username" value="${sessionScope.user.username}" readonly>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Trạng thái</label>
+                            <select class="form-select" name="status" id="status">
+                                <option value="pending">Chờ xử lý</option>
+                                <option value="confirmed">Đã xác nhận</option>
+                                <option value="cancelled">Đã hủy</option>
+                                <option value="completed">Hoàn thành</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                        <button type="submit" class="btn btn-primary">Lưu</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 </div>
 <jsp:include page="homefooter.jsp" />
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         var calendarEl = document.getElementById('calendar');
+        var bookingModal = new bootstrap.Modal(document.getElementById('bookingModal'));
+        var bookingForm = document.getElementById('bookingForm');
+        var bookingIdField = document.getElementById('bookingId');
+        var bookingDate = document.getElementById('bookingDate');
+        var startTime = document.getElementById('startTime');
+        var endTime = document.getElementById('endTime');
+        var courtId = document.getElementById('courtId');
+        var statusSelect = document.getElementById('status');
+
         var calendar = new FullCalendar.Calendar(calendarEl, {
             initialView: 'dayGridMonth',
             headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek' },
+            dateClick: function(info) {
+                bookingForm.reset();
+                bookingIdField.value = '';
+                bookingDate.value = info.dateStr;
+                bookingModal.show();
+            },
+            eventClick: function(info) {
+                var ev = info.event;
+                bookingForm.reset();
+                bookingIdField.value = ev.id;
+                bookingDate.value = ev.startStr.substring(0,10);
+                startTime.value = ev.startStr.substring(11,16);
+                endTime.value = ev.endStr.substring(11,16);
+                courtId.value = ev.extendedProps.courtId;
+                statusSelect.value = ev.extendedProps.status;
+                bookingModal.show();
+            },
             events: [
                 <c:forEach var="b" items="${bookings}" varStatus="loop">
                 {
+                    id: '${b.booking_id}',
                     title: 'Sân ${b.court_id} - ${b.status}',
                     start: '${b.date}T${fn:substring(b.start_time,0,5)}',
-                    end: '${b.date}T${fn:substring(b.end_time,0,5)}'
+                    end: '${b.date}T${fn:substring(b.end_time,0,5)}',
+                    extendedProps: { courtId: ${b.court_id}, status: '${b.status}' }
                 }<c:if test="${!loop.last}">,</c:if>
                 </c:forEach>
             ]


### PR DESCRIPTION
## Summary
- show a Bootstrap modal on the booking calendar page
- store courts list in `UserBookingCalendar` servlet
- add servlet to handle modal booking actions
- wire FullCalendar date and event clicks to open the modal

## Testing
- `javac -classpath ../lib/*:/usr/share/java/jakarta-servlet-api.jar:src/java -d build/classes src/java/controller/calendar/CalendarBookingServlet.java`

------
https://chatgpt.com/codex/tasks/task_b_687c1232a4b8832eabb409d6c7ff601e