### PR TITLE
Refactor calendar modal

### DIFF
--- a/Project_SWP/web/booking_calendar.jsp
+++ b/Project_SWP/web/booking_calendar.jsp
@@ -14,81 +14,37 @@
 <jsp:include page="homehead.jsp" />
 <div class="container mt-4">
     <h2 class="mb-3">Lịch đặt sân của bạn</h2>
-    <form id="filterForm" class="row g-3" method="get" action="booking-calendar">
-        <div class="col-md-3">
-            <label class="form-label">Từ ngày</label>
-            <input type="date" class="form-control" name="fromDate" value="${fromDate}">
-        </div>
-        <div class="col-md-3">
-            <label class="form-label">Đến ngày</label>
-            <input type="date" class="form-control" name="toDate" value="${toDate}">
-        </div>
-        <div class="col-md-3">
-            <label class="form-label">Trạng thái</label>
-            <select class="form-select" name="status">
-                <option value="" ${empty status ? 'selected' : ''}>Tất cả</option>
-                <option value="pending" ${status=='pending'? 'selected':''}>Chờ xử lý</option>
-                <option value="confirmed" ${status=='confirmed'? 'selected':''}>Đã xác nhận</option>
-                <option value="cancelled" ${status=='cancelled'? 'selected':''}>Đã hủy</option>
-                <option value="completed" ${status=='completed'? 'selected':''}>Hoàn thành</option>
-            </select>
-        </div>
-        <div class="col-md-3 align-self-end">
-            <button type="submit" class="btn btn-primary w-100">Lọc</button>
-        </div>
-    </form>
     <div id='calendar'></div>
 
-    <!-- Booking Modal -->
-    <div class="modal fade" id="bookingModal" tabindex="-1" aria-hidden="true">
+    <!-- Booking Detail Modal -->
+    <div class="modal fade" id="bookingDetailModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
-                <form id="bookingForm" action="calendar-booking" method="post">
-                    <div class="modal-header">
-                        <h5 class="modal-title">Đặt sân</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <div class="modal-header">
+                    <h5 class="modal-title">Chi tiết đặt sân</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Sân</label>
+                        <input type="text" class="form-control" id="detailCourt" readonly>
                     </div>
-                    <div class="modal-body">
-                        <input type="hidden" name="bookingId" id="bookingId">
-                        <div class="mb-3">
-                            <label class="form-label">Ngày</label>
-                            <input type="date" class="form-control" name="date" id="bookingDate" required>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Bắt đầu</label>
-                            <input type="time" class="form-control" name="startTime" id="startTime" required>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Kết thúc</label>
-                            <input type="time" class="form-control" name="endTime" id="endTime" required>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Sân</label>
-                            <select class="form-select" name="courtId" id="courtId" required>
-                                <c:forEach var="c" items="${courts}">
-                                    <option value="${c.court_id}">Sân ${c.court_number}</option>
-                                </c:forEach>
-                            </select>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Người đặt</label>
-                            <input type="text" class="form-control" name="username" value="${sessionScope.user.username}" readonly>
-                        </div>
-                        <div class="mb-3">
-                            <label class="form-label">Trạng thái</label>
-                            <select class="form-select" name="status" id="status">
-                                <option value="pending">Chờ xử lý</option>
-                                <option value="confirmed">Đã xác nhận</option>
-                                <option value="cancelled">Đã hủy</option>
-                                <option value="completed">Hoàn thành</option>
-                            </select>
-                        </div>
+                    <div class="mb-3">
+                        <label class="form-label">Ngày</label>
+                        <input type="text" class="form-control" id="detailDate" readonly>
                     </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
-                        <button type="submit" class="btn btn-primary">Lưu</button>
+                    <div class="mb-3">
+                        <label class="form-label">Thời gian</label>
+                        <input type="text" class="form-control" id="detailTime" readonly>
                     </div>
-                </form>
+                    <div class="mb-3">
+                        <label class="form-label">Trạng thái</label>
+                        <input type="text" class="form-control" id="detailStatus" readonly>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                </div>
             </div>
         </div>
     </div>
@@ -99,34 +55,22 @@
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         var calendarEl = document.getElementById('calendar');
-        var bookingModal = new bootstrap.Modal(document.getElementById('bookingModal'));
-        var bookingForm = document.getElementById('bookingForm');
-        var bookingIdField = document.getElementById('bookingId');
-        var bookingDate = document.getElementById('bookingDate');
-        var startTime = document.getElementById('startTime');
-        var endTime = document.getElementById('endTime');
-        var courtId = document.getElementById('courtId');
-        var statusSelect = document.getElementById('status');
+        var detailModal = new bootstrap.Modal(document.getElementById('bookingDetailModal'));
+        var detailCourt = document.getElementById('detailCourt');
+        var detailDate = document.getElementById('detailDate');
+        var detailTime = document.getElementById('detailTime');
+        var detailStatus = document.getElementById('detailStatus');
 
         var calendar = new FullCalendar.Calendar(calendarEl, {
             initialView: 'dayGridMonth',
             headerToolbar: { left: 'prev,next today', center: 'title', right: 'dayGridMonth,timeGridWeek' },
-            dateClick: function(info) {
-                bookingForm.reset();
-                bookingIdField.value = '';
-                bookingDate.value = info.dateStr;
-                bookingModal.show();
-            },
             eventClick: function(info) {
                 var ev = info.event;
-                bookingForm.reset();
-                bookingIdField.value = ev.id;
-                bookingDate.value = ev.startStr.substring(0,10);
-                startTime.value = ev.startStr.substring(11,16);
-                endTime.value = ev.endStr.substring(11,16);
-                courtId.value = ev.extendedProps.courtId;
-                statusSelect.value = ev.extendedProps.status;
-                bookingModal.show();
+                detailCourt.value = ev.extendedProps.courtId;
+                detailDate.value = ev.startStr.substring(0,10);
+                detailTime.value = ev.startStr.substring(11,16) + ' - ' + ev.endStr.substring(11,16);
+                detailStatus.value = ev.extendedProps.status;
+                detailModal.show();
             },
             eventSources: [
                 [
@@ -139,28 +83,10 @@
                         extendedProps: { courtId: ${b.court_id}, status: '${b.status}' }
                     }<c:if test="${!loop.last}">,</c:if>
                     </c:forEach>
-                ],
-                {
-                    url: '<c:url value="/booking-calendar" />',
-                    method: 'POST',
-                    extraParams: function() {
-                        var formData = new FormData(filterForm);
-                        var params = { format: 'json' };
-                        formData.forEach(function(value, key) {
-                            if (value) {
-                                params[key] = value;
-                            }
-                        });
-                        return params;
-                    }
-                }
+                ]
             ]
         });
         calendar.render();
-        filterForm.addEventListener('submit', function(e) {
-            e.preventDefault();
-            calendar.refetchEvents();
-        });
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- remove filtering form and edit modal from `booking_calendar.jsp`
- add read-only booking detail modal
- load modal details on event click
- simplify event sources to use server data

## Testing
- `ant -f Project_SWP/build.xml -noinput -q` *(fails: libs.CopyLibs.classpath property is not set up)*

------
https://chatgpt.com/codex/tasks/task_b_687d7436311c832eaa99009e590defb0